### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "build": "node_modules/.bin/babel lib/ -d dist/",
     "prepublish": "npm run-script test-dev"
   },
+  "files": [
+    "lib",
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/SplittyDev/evee.js.git"


### PR DESCRIPTION
With this change, unnecessary files (such as `test.js` and `benchmark.js`) will not be published to npm.  `index.js`, `lib`, and `dist` will.  You can check which files are published to npm by running `npm pack`.
