### PR TITLE
Fix: drop() removing the wrong event/item.

### DIFF
--- a/lib/evee.js
+++ b/lib/evee.js
@@ -80,8 +80,13 @@ class Evee {
     for (let i = 0; i < this.receivers.length; i++) {
       let items = this.receivers[i];
       if (items.length > 0 && items[0].name === event.name) {
-        items.splice(i, 1);
-        return true;
+        for (let i = 0; i < items.length; i++) {
+          if (items[i] === event) {
+            items.splice(i, 1);
+            return true;
+          }
+        }
+        return false;
       }
     }
     return false;


### PR DESCRIPTION
Fix: drop() removing the wrong event/item.

The item was being spliced out based on the receiver's index instead of the item's index in the items array.
